### PR TITLE
sc_pref_pl_display_name_title made more clear

### DIFF
--- a/schildi/lib/src/main/res/values/strings.xml
+++ b/schildi/lib/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="sc_pref_sc_timeline_layout_title">SC conversation layout</string>
     <string name="sc_pref_sc_floating_date_title">Floating date</string>
     <string name="sc_pref_sc_floating_date_summary">Show the date on top of messages while scrolling</string>
-    <string name="sc_pref_pl_display_name_title">Name colors by power level</string>
+    <string name="sc_pref_pl_display_name_title">Nickname colors differ by role</string>
     <string name="sc_pref_pl_display_name_summary_warning">Does not work reliably when member list was not fully fetched yet</string>
     <string name="sc_pref_el_typography_title">Element typography</string>
     <string name="sc_pref_el_typography_summary">Use Element\'s font settings with larger message text</string>


### PR DESCRIPTION
Addresses #100 

"Name colors by power level" changed to "Nickname colors differ by role"