### PR TITLE
implement auto-hide buttons during call

### DIFF
--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenEvent.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenEvent.kt
@@ -14,4 +14,5 @@ sealed interface CallScreenEvent {
     data object Hangup : CallScreenEvent
     data class SetupMessageChannels(val widgetMessageInterceptor: WidgetMessageInterceptor) : CallScreenEvent
     data class OnWebViewError(val description: String?) : CallScreenEvent
+    data object ScreenTapped : CallScreenEvent
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenPresenter.kt
@@ -42,6 +42,7 @@ import io.element.android.services.analytics.api.ScreenTracker
 import io.element.android.services.appnavstate.api.AppForegroundStateService
 import io.element.android.services.toolbox.api.systemclock.SystemClock
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -49,6 +50,8 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
+
+private val AUTO_HIDE_DELAY = 5.seconds
 
 @AssistedInject
 class CallScreenPresenter(
@@ -81,10 +84,32 @@ class CallScreenPresenter(
         val callWidgetDriver = remember { mutableStateOf<MatrixWidgetDriver?>(null) }
         val messageInterceptor = remember { mutableStateOf<WidgetMessageInterceptor?>(null) }
         var isWidgetLoaded by rememberSaveable { mutableStateOf(false) }
+        var hasCallJoined by remember { mutableStateOf(false) }
         var ignoreWebViewError by rememberSaveable { mutableStateOf(false) }
         var webViewError by remember { mutableStateOf<String?>(null) }
+        var areControlsVisible by remember { mutableStateOf(true) }
         val languageTag = languageTagProvider.provideLanguageTag()
         val theme = if (ElementTheme.isLightTheme) "light" else "dark"
+
+        // Auto-hide timer: resets on each user interaction
+        var autoHideJob by remember { mutableStateOf<Job?>(null) }
+
+        // Start the auto-hide timer when the call is active
+        fun startAutoHideTimer() {
+            autoHideJob?.cancel()
+            autoHideJob = coroutineScope.launch {
+                delay(AUTO_HIDE_DELAY)
+                areControlsVisible = false
+            }
+        }
+
+        fun resetAutoHideTimer() {
+            areControlsVisible = true
+            startAutoHideTimer()
+        }
+
+        // The auto-hide timer only starts when the user joins the call (Join message).
+        // On the lobby screen, taps via ScreenTapped are ignored (hasCallJoined == false).
 
         DisposableEffect(Unit) {
             coroutineScope.launch {
@@ -133,6 +158,10 @@ class CallScreenPresenter(
                                 close(callWidgetDriver.value, navigator)
                             } else if (parsedMessage.action == WidgetMessage.Action.ContentLoaded) {
                                 isWidgetLoaded = true
+                            } else if (parsedMessage.action == WidgetMessage.Action.Join) {
+                                // Start the auto-hide timer when the user actually joins the call
+                                hasCallJoined = true
+                                startAutoHideTimer()
                             }
                         }
                     }
@@ -155,6 +184,9 @@ class CallScreenPresenter(
         fun handleEvent(event: CallScreenEvent) {
             when (event) {
                 is CallScreenEvent.Hangup -> {
+                    // Cancel auto-hide timer when hanging up
+                    autoHideJob?.cancel()
+                    autoHideJob = null
                     val widgetId = callWidgetDriver.value?.id
                     val interceptor = messageInterceptor.value
                     if (widgetId != null && interceptor != null && isWidgetLoaded) {
@@ -183,6 +215,16 @@ class CallScreenPresenter(
                     }
                     // Else ignore the error, give a chance the Element Call to recover by itself.
                 }
+                is CallScreenEvent.ScreenTapped -> {
+                    // Don't start the auto-hide timer before the user has joined the call
+                    if (!hasCallJoined) return@handleEvent
+                    if (!areControlsVisible) {
+                        resetAutoHideTimer()
+                    } else {
+                        // Controls are already visible, just reset the timer
+                        startAutoHideTimer()
+                    }
+                }
             }
         }
 
@@ -191,6 +233,7 @@ class CallScreenPresenter(
             webViewError = webViewError,
             userAgent = userAgent,
             isCallActive = isWidgetLoaded,
+            areControlsVisible = areControlsVisible,
             eventSink = ::handleEvent,
         )
     }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenState.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenState.kt
@@ -15,5 +15,6 @@ data class CallScreenState(
     val webViewError: String?,
     val userAgent: String,
     val isCallActive: Boolean,
+    val areControlsVisible: Boolean = true,
     val eventSink: (CallScreenEvent) -> Unit,
 )

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenStateProvider.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenStateProvider.kt
@@ -15,6 +15,7 @@ open class CallScreenStateProvider : PreviewParameterProvider<CallScreenState> {
     override val values: Sequence<CallScreenState>
         get() = sequenceOf(
             aCallScreenState(),
+            aCallScreenState(areControlsVisible = false),
             aCallScreenState(urlState = AsyncData.Loading()),
             aCallScreenState(urlState = AsyncData.Failure(Exception("An error occurred"))),
             aCallScreenState(webViewError = "Error details from WebView"),
@@ -26,6 +27,7 @@ internal fun aCallScreenState(
     webViewError: String? = null,
     userAgent: String = "",
     isCallActive: Boolean = true,
+    areControlsVisible: Boolean = true,
     eventSink: (CallScreenEvent) -> Unit = {},
 ): CallScreenState {
     return CallScreenState(
@@ -33,6 +35,7 @@ internal fun aCallScreenState(
         webViewError = webViewError,
         userAgent = userAgent,
         isCallActive = isCallActive,
+        areControlsVisible = areControlsVisible,
         eventSink = eventSink,
     )
 }

--- a/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
+++ b/features/call/impl/src/main/kotlin/io/element/android/features/call/impl/ui/CallScreenView.kt
@@ -9,6 +9,7 @@
 package io.element.android.features.call.impl.ui
 
 import android.annotation.SuppressLint
+import android.view.MotionEvent
 import android.view.ViewGroup
 import android.webkit.ConsoleMessage
 import android.webkit.JavascriptInterface
@@ -22,6 +23,7 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -98,59 +100,176 @@ internal fun CallScreenView(
             }
         }
 
-        CallWebView(
-            modifier = modifier.consumeWindowInsets(WindowInsets.systemBars).fillMaxSize(),
-            url = state.urlState,
-            userAgent = state.userAgent,
-            onPermissionsRequest = { request ->
-                val androidPermissions = mapWebkitPermissions(request.resources)
-                val callback: RequestPermissionCallback = { request.grant(it) }
-                requestPermissions(androidPermissions.toTypedArray(), callback)
-            },
-            onConsoleMessage = onConsoleMessage,
-            onCreateWebView = { webView ->
-                callWebView = webView
-                webView.addBackHandler(onBackPressed = ::handleBack)
-                val interceptor = WebViewWidgetMessageInterceptor(
-                    webView = webView,
-                    onUrlLoaded = { url ->
-                        webView.evaluateJavascript("controls.onBackButtonPressed = () => { backHandler.onBackPressed() }", null)
-                        if (webViewAudioManager?.isInCallMode?.get() == false) {
-                            Timber.d("URL $url is loaded, starting in-call audio mode")
-                            webViewAudioManager?.onCallStarted()
-                        } else {
-                            Timber.d("Can't start in-call audio mode since the app is already in it.")
+        Box(modifier = modifier.fillMaxSize()) {
+            CallWebView(
+                modifier = Modifier
+                    .consumeWindowInsets(WindowInsets.systemBars)
+                    .fillMaxSize(),
+                url = state.urlState,
+                userAgent = state.userAgent,
+                onPermissionsRequest = { request ->
+                    val androidPermissions = mapWebkitPermissions(request.resources)
+                    val callback: RequestPermissionCallback = { request.grant(it) }
+                    requestPermissions(androidPermissions.toTypedArray(), callback)
+                },
+                onConsoleMessage = onConsoleMessage,
+                onCreateWebView = { webView ->
+                    callWebView = webView
+                    webView.addBackHandler(onBackPressed = ::handleBack)
+
+                    // Native touch listener: every tap on the WebView resets the auto-hide timer.
+                    // Returns false so the WebView processes the touch normally.
+                    // This catches touches at the Android View level, before Element Call's JS
+                    // can intercept them (Element Call suppresses click event synthesis).
+                    webView.setOnTouchListener { _, event ->
+                        if (event.action == MotionEvent.ACTION_UP) {
+                            state.eventSink(CallScreenEvent.ScreenTapped)
                         }
-                    },
-                    onError = { state.eventSink(CallScreenEvent.OnWebViewError(it)) },
-                )
-                webViewAudioManager = WebViewAudioManager(
-                    webView = webView,
-                    coroutineScope = coroutineScope,
-                    onInvalidAudioDeviceAdded = { invalidAudioDeviceReason = it },
-                )
-                state.eventSink(CallScreenEvent.SetupMessageChannels(interceptor))
-                val pipController = WebViewPipController(webView)
-                pipState.eventSink(PictureInPictureEvent.SetPipController(pipController))
-            },
-            onDestroyWebView = {
-                callWebView = null
-                // Reset audio mode
-                webViewAudioManager?.onCallStopped()
+                        false
+                    }
+
+                    val interceptor = WebViewWidgetMessageInterceptor(
+                        webView = webView,
+                        onUrlLoaded = { url ->
+                            webView.evaluateJavascript("controls.onBackButtonPressed = () => { backHandler.onBackPressed() }", null)
+                            if (webViewAudioManager?.isInCallMode?.get() == false) {
+                                Timber.d("URL $url is loaded, starting in-call audio mode")
+                                webViewAudioManager?.onCallStarted()
+                            } else {
+                                Timber.d("Can't start in-call audio mode since the app is already in it.")
+                            }
+                        },
+                        onError = { state.eventSink(CallScreenEvent.OnWebViewError(it)) },
+                    )
+                    webViewAudioManager = WebViewAudioManager(
+                        webView = webView,
+                        coroutineScope = coroutineScope,
+                        onInvalidAudioDeviceAdded = { invalidAudioDeviceReason = it },
+                    )
+                    state.eventSink(CallScreenEvent.SetupMessageChannels(interceptor))
+                    val pipController = WebViewPipController(webView)
+                    pipState.eventSink(PictureInPictureEvent.SetPipController(pipController))
+                },
+                onDestroyWebView = {
+                    callWebView = null
+                    webViewAudioManager?.onCallStopped()
+                }
+            )
+
+            // Inject CSS to animate Element Call controls. The OnTouchListener on the WebView
+            // (set up in onCreateWebView) handles tap detection for both showing controls
+            // and resetting the auto-hide timer — without blocking touches from reaching
+            // any visible elements underneath (menu items, buttons, etc.).
+            LaunchedEffect(state.areControlsVisible, callWebView) {
+                val webView = callWebView ?: return@LaunchedEffect
+                val visible = state.areControlsVisible
+                val js = """
+                    (function() {
+                        var VISIBLE = $visible;
+                        var HIDE_CLASS = 'sc-controls-hidden';
+                        var TOP_CLASS = 'sc-controls-top';
+                        var BOTTOM_CLASS = 'sc-controls-bottom';
+
+                        // Inject CSS once
+                        if (!document.getElementById('sc-controls-style')) {
+                            var style = document.createElement('style');
+                            style.id = 'sc-controls-style';
+                            style.textContent = [
+                                '.sc-controls-hidden {',
+                                '  opacity: 0 !important;',
+                                '  pointer-events: none !important;',
+                                '  transition: opacity 0.3s ease, transform 0.3s ease !important;',
+                                '}',
+                                '.sc-controls-top.sc-controls-hidden {',
+                                '  transform: translateY(-100%) !important;',
+                                '}',
+                                '.sc-controls-bottom.sc-controls-hidden {',
+                                '  transform: translateY(100%) !important;',
+                                '}',
+                                '.sc-controls-top, .sc-controls-bottom {',
+                                '  transition: opacity 0.3s ease, transform 0.3s ease !important;',
+                                '}',
+                            ].join('\n');
+                            document.head.appendChild(style);
+                        }
+
+                        // Only hide elements at screen edges (not mid-page menu/popup content)
+                        function isNearTop(el) {
+                            return el.getBoundingClientRect().top < 80;
+                        }
+                        function isNearBottom(el) {
+                            return el.getBoundingClientRect().bottom > window.innerHeight - 80;
+                        }
+
+                        var topSelectors = [
+                            'header', 'nav',
+                            '[class*="topBar"]', '[class*="TopBar"]',
+                            '[class*="headerBar"]', '[class*="HeaderBar"]',
+                            '[class*="topControls"]', '[class*="TopControls"]',
+                            '[class*="roomHeader"]', '[class*="RoomHeader"]',
+                            '[class*="callHeader"]', '[class*="CallHeader"]',
+                        ];
+
+                        var bottomSelectors = [
+                            '[class*="controlsBar"]', '[class*="ControlsBar"]',
+                            '[class*="bottomBar"]', '[class*="BottomBar"]',
+                            '[class*="callControls"]', '[class*="CallControls"]',
+                            '[class*="controlsContainer"]', '[class*="ControlsContainer"]',
+                            '[data-testid="call-controls"]',
+                            '[class*="actionBar"]', '[class*="ActionBar"]',
+                            '[class*="buttonBar"]', '[class*="ButtonBar"]',
+                            '[class*="footer"]', '[class*="Footer"]',
+                        ];
+
+                        function toggleAll(selectors, cls, posCheck) {
+                            for (var i = 0; i < selectors.length; i++) {
+                                var els = document.querySelectorAll(selectors[i]);
+                                for (var j = 0; j < els.length; j++) {
+                                    var el = els[j];
+                                    if (posCheck && !posCheck(el)) continue;
+                                    if (VISIBLE) {
+                                        el.classList.remove(HIDE_CLASS);
+                                        el.classList.remove(cls);
+                                    } else {
+                                        el.classList.add(HIDE_CLASS);
+                                        el.classList.add(cls);
+                                    }
+                                }
+                            }
+                        }
+
+                        toggleAll(topSelectors, TOP_CLASS, isNearTop);
+                        toggleAll(bottomSelectors, BOTTOM_CLASS, isNearBottom);
+
+                        // Camera switch button in video tile, no position check
+                        var cameraSelectors = [
+                            '[class*="switchCamera"]', '[class*="SwitchCamera"]',
+                        ];
+                        toggleAll(cameraSelectors, BOTTOM_CLASS, null);
+
+                        try {
+                            if (typeof controls !== 'undefined' && controls.setControlsVisible) {
+                                controls.setControlsVisible(VISIBLE);
+                            }
+                        } catch(e) {}
+                    })();
+                """.trimIndent()
+                webView.evaluateJavascript(js, null)
             }
-        )
-        when (state.urlState) {
-            AsyncData.Uninitialized,
-            is AsyncData.Loading ->
-                ProgressDialog(text = stringResource(id = CommonStrings.common_please_wait))
-            is AsyncData.Failure -> {
-                Timber.e(state.urlState.error, "WebView failed to load URL: ${state.urlState.error.message}")
-                ErrorDialog(
-                    content = state.urlState.error.message.orEmpty(),
-                    onSubmit = { state.eventSink(CallScreenEvent.Hangup) },
-                )
+
+            when (state.urlState) {
+                AsyncData.Uninitialized,
+                is AsyncData.Loading ->
+                    ProgressDialog(text = stringResource(id = CommonStrings.common_please_wait))
+                is AsyncData.Failure -> {
+                    Timber.e(state.urlState.error, "WebView failed to load URL: ${state.urlState.error.message}")
+                    ErrorDialog(
+                        content = state.urlState.error.message.orEmpty(),
+                        onSubmit = { state.eventSink(CallScreenEvent.Hangup) },
+                    )
+                }
+                is AsyncData.Success -> Unit
             }
-            is AsyncData.Success -> Unit
         }
     }
 }

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenPresenterTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenPresenterTest.kt
@@ -10,6 +10,7 @@ package io.element.android.features.call.ui
 
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
+import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import im.vector.app.features.analytics.plan.MobileScreen
@@ -301,7 +302,105 @@ class CallScreenPresenterTest {
         }
     }
 
-    private fun TestScope.createCallScreenPresenter(
+    @Test
+    fun `present - areControlsVisible starts as true`() = runTest {
+        val widgetDriver = FakeMatrixWidgetDriver()
+        val presenter = createCallScreenPresenter(
+            callData = CallData(A_SESSION_ID, A_ROOM_ID, false),
+            widgetDriver = widgetDriver,
+            screenTracker = FakeScreenTracker {},
+        )
+        presenter.test {
+            advanceTimeBy(1.seconds)
+            val initialState = awaitItem()
+            assertThat(initialState.areControlsVisible).isTrue()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - ScreenTapped resets timer and controls stay visible`() = runTest {
+        val widgetDriver = FakeMatrixWidgetDriver()
+        val presenter = createCallScreenPresenter(
+            callData = CallData(A_SESSION_ID, A_ROOM_ID, false),
+            widgetDriver = widgetDriver,
+            screenTracker = FakeScreenTracker {},
+        )
+        val messageInterceptor = FakeWidgetMessageInterceptor()
+        presenter.test {
+            val stateBeforeTap = simulateCallJoined(messageInterceptor)
+            assertThat(stateBeforeTap.areControlsVisible).isTrue()
+
+            // Tap the screen to reset the timer
+            stateBeforeTap.eventSink(CallScreenEvent.ScreenTapped)
+
+            // Advance time past the original 5s deadline (4 seconds after tap)
+            // The original timer was cancelled by the tap, so controls should still be visible
+            advanceTimeBy(4.seconds)
+            val stillVisible = awaitItem()
+            assertThat(stillVisible.areControlsVisible).isTrue()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - controls auto-hide after timeout when user has joined`() = runTest {
+        val widgetDriver = FakeMatrixWidgetDriver()
+        val presenter = createCallScreenPresenter(
+            callData = CallData(A_SESSION_ID, A_ROOM_ID, false),
+            widgetDriver = widgetDriver,
+            screenTracker = FakeScreenTracker {},
+        )
+        val messageInterceptor = FakeWidgetMessageInterceptor()
+        presenter.test {
+            simulateCallJoined(messageInterceptor)
+
+            // Advance time past the 5s auto-hide timeout
+            advanceTimeBy(6.seconds)
+            val afterTimeout = awaitItem()
+            assertThat(afterTimeout.areControlsVisible).isFalse()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}
+
+private const val CONTENT_LOADED_JSON = """
+    {
+        "action":"content_loaded",
+        "api":"fromWidget",
+        "widgetId":"1",
+        "requestId":"1"
+    }
+"""
+
+private const val IO_ELEMENT_JOIN_JSON = """
+    {
+        "action":"io.element.join",
+        "api":"fromWidget",
+        "widgetId":"1",
+        "requestId":"1"
+    }
+"""
+
+/**
+ * Sets up the message interceptor, sends content_loaded and join messages,
+ * and returns the state after the join timer has started.
+ */
+private suspend fun TurbineTestContext<CallScreenState>.simulateCallJoined(
+    messageInterceptor: FakeWidgetMessageInterceptor,
+): CallScreenState {
+    advanceTimeBy(1.seconds)
+    val initialState = awaitItem()
+    initialState.eventSink(CallScreenEvent.SetupMessageChannels(messageInterceptor))
+    messageInterceptor.givenInterceptedMessage(CONTENT_LOADED_JSON.trimIndent())
+    skipItems(2)
+    messageInterceptor.givenInterceptedMessage(IO_ELEMENT_JOIN_JSON.trimIndent())
+    return awaitItem()
+}
+
+private fun TestScope.createCallScreenPresenter(
         callData: CallData,
         navigator: CallScreenNavigator = FakeCallScreenNavigator(),
         widgetDriver: FakeMatrixWidgetDriver = FakeMatrixWidgetDriver(),

--- a/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenViewTest.kt
+++ b/features/call/impl/src/test/kotlin/io/element/android/features/call/ui/CallScreenViewTest.kt
@@ -93,6 +93,18 @@ class CallScreenViewTest {
         pipEvents.assertTrue(0) { it is PictureInPictureEvent.SetPipController }
         pipEvents.assertTrue(1) { it is PictureInPictureEvent.EnterPictureInPicture }
     }
+
+    @Test
+    fun `areControlsVisible false does not crash the view`() = runAndroidComposeUiTest {
+        setCallScreenView(
+            state = aCallScreenState(
+                areControlsVisible = false,
+                eventSink = EventsRecorder(),
+            ),
+            useInspectionMode = true,
+        )
+        // Verify that composing with areControlsVisible = false doesn't crash
+    }
 }
 
 @OptIn(ExperimentalTestApi::class)


### PR DESCRIPTION
After joining a call, the header and bottom control bars now automatically hide after 5 seconds of inactivity to reduce visual clutter and show more of the video feed. Tapping anywhere on the call surface reveals the controls and resets the timer.

How it works:
- A native MotionEvent touch listener on the WebView detects taps and dispatches ScreenTapped events without blocking touches from reaching the underlying call UI.
- The presenter starts a 5-second auto-hide timer when a Join message is received from the call widget. Each tap cancels and restarts the timer.
- When the timer fires, areControlsVisible = false triggers a LaunchedEffect that injects CSS into the WebView, targeting top/bottom UI elements by class name pattern and hiding them with opacity: 0 + pointer-events: none with a smooth transition.
- Position-based filtering ensures only elements at screen edges are hidden — mid-page menus, popups, and buttons remain unaffected.
- The timer only starts after the user actually joins the call (not on the lobby screen), and is cancelled on hangup.


