### PR TITLE
Add option to hide voice message button

### DIFF
--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/TextComposer.kt
@@ -82,6 +82,7 @@ import io.element.android.libraries.matrix.ui.messages.reply.InReplyToDetailsPro
 import io.element.android.libraries.matrix.ui.messages.reply.aProfileDetailsReady
 import io.element.android.libraries.testtags.TestTags
 import io.element.android.libraries.testtags.testTag
+import io.element.android.libraries.textcomposer.components.scShowVoiceRecorderButton
 import io.element.android.libraries.textcomposer.components.SendButtonIcon
 import io.element.android.libraries.textcomposer.components.TextFormatting
 import io.element.android.libraries.textcomposer.components.VoiceMessageDeleteButtonIcon
@@ -238,13 +239,30 @@ fun TextComposer(
         hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
     }
 
+    val scShowVoiceRecorderButton = scShowVoiceRecorderButton()
+
     @Composable
     fun rememberEndButtonParams() = remember(
         composerMode.isEditing,
         voiceMessageState.endButtonKey(),
         canSendTextMessage,
+        scShowVoiceRecorderButton,
     ) {
         when {
+            // SchildiChat: when the voice message button is hidden (issue #99), an empty composer in
+            // the idle state shows a (disabled) send button instead of the recorder, so the composer
+            // stays usable and tapping where the recorder used to be does not start a recording.
+            !canSendTextMessage && voiceMessageState == VoiceMessageState.Idle && !scShowVoiceRecorderButton ->
+                EndButtonParams(
+                    endButtonContentDescriptionResId = CommonStrings.action_send_message,
+                    endButtonClick = {},
+                    endButtonContent = @Composable {
+                        SendButtonIcon(
+                            canSendMessage = false,
+                            isEditing = false,
+                        )
+                    },
+                )
             !canSendTextMessage ->
                 when (voiceMessageState) {
                     VoiceMessageState.Idle -> EndButtonParams(

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/ScSendButtonExtensions.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/components/ScSendButtonExtensions.kt
@@ -3,6 +3,8 @@ package io.element.android.libraries.textcomposer.components
 import androidx.compose.foundation.background
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import chat.schildi.lib.preferences.ScPrefs
+import chat.schildi.lib.preferences.value
 import chat.schildi.theme.ScTheme
 import io.element.android.compound.theme.ElementTheme
 
@@ -18,3 +20,10 @@ fun scSendButtonTint() = when {
     !ScTheme.yes -> null
     else -> ScTheme.exposures.colorOnAccent
 }
+
+/**
+ * Whether the voice message record button should be shown in the composer's end-button slot.
+ * SchildiChat lets users hide it (issue #99) to avoid recording by accident.
+ */
+@Composable
+fun scShowVoiceRecorderButton(): Boolean = !ScPrefs.HIDE_VOICE_MESSAGE_BUTTON.value()

--- a/schildi/lib/src/main/kotlin/chat/schildi/lib/preferences/ScPrefs.kt
+++ b/schildi/lib/src/main/kotlin/chat/schildi/lib/preferences/ScPrefs.kt
@@ -105,6 +105,7 @@ object ScPrefs {
     val PINNED_MESSAGE_OVERLAY = ScBoolPref("PINNED_MESSAGE_OVERLAY", false, R.string.sc_pref_pinned_message_overlay_title, R.string.sc_pref_pinned_message_overlay_summary, authorsChoice = false, upstreamChoice = true)
     val PINNED_MESSAGE_TOOLBAR_ACTION = ScBoolPref("PINNED_MESSAGE_TOOLBAR_ACTION", true, R.string.sc_pref_pinned_message_toolbar_title, R.string.sc_pref_pinned_message_toolbar_summary, authorsChoice = true, upstreamChoice = false, dependencies = PINNED_MESSAGE_OVERLAY.asDependencies(expect = false), disabledValue = false)
     val HIDE_CALL_TOOLBAR_ACTION = ScBoolPref("HIDE_CALL_TOOLBAR_ACTION", false, R.string.sc_pref_hide_call_toolbar_action_title, R.string.sc_pref_hide_call_toolbar_action_summary, authorsChoice = true, upstreamChoice = false)
+    val HIDE_VOICE_MESSAGE_BUTTON = ScBoolPref("HIDE_VOICE_MESSAGE_BUTTON", false, R.string.sc_pref_hide_voice_message_button_title, R.string.sc_pref_hide_voice_message_button_summary, authorsChoice = false, upstreamChoice = false)
     val SC_TIMELINE_LAYOUT = ScBoolPref("SC_TIMELINE_LAYOUT", true, R.string.sc_pref_sc_timeline_layout_title, R.string.sc_pref_sc_layout_summary, upstreamChoice = false)
     val FLOATING_DATE = ScBoolPref("FLOATING_DATE", true, R.string.sc_pref_sc_floating_date_title, R.string.sc_pref_sc_floating_date_summary, upstreamChoice = false)
     val PL_DISPLAY_NAME = ScBoolPref("PL_DISPLAY_NAME", false, R.string.sc_pref_pl_display_name_title, R.string.sc_pref_pl_display_name_summary_warning, authorsChoice = false, upstreamChoice = false)
@@ -213,6 +214,7 @@ object ScPrefs {
             //RENDER_INLINE_IMAGES,
             FLOATING_DATE,
             HIDE_CALL_TOOLBAR_ACTION,
+            HIDE_VOICE_MESSAGE_BUTTON,
             VERBOSE_CONVERSATION_ICONS,
             REPLY_PREVIEW_LINE_COUNT,
             LEGACY_MESSAGE_RENDERING,

--- a/schildi/lib/src/main/res/values/strings.xml
+++ b/schildi/lib/src/main/res/values/strings.xml
@@ -111,6 +111,8 @@
     <string name="sc_pref_user_changed_prefs_empty">Everything is default</string>
     <string name="sc_pref_hide_call_toolbar_action_title">Hide call action</string>
     <string name="sc_pref_hide_call_toolbar_action_summary">Move call action into overflow menu, and hide completely when the chat does not allow calls</string>
+    <string name="sc_pref_hide_voice_message_button_title">Hide voice message button</string>
+    <string name="sc_pref_hide_voice_message_button_summary">Hide the voice message record button in the composer to avoid recording by accident</string>
     <string name="sc_pref_hide_invites_title">Hide invites</string>
     <string name="sc_pref_hide_invites_summary">Do not show any invites in the app. Note there is another setting to not notify for invites in notification settings.</string>
     <string name="sc_pref_syncing_indicator_title">Sync indicator</string>


### PR DESCRIPTION
## Summary

Adds a SchildiChat preference to hide the voice message record button in the message composer.

- New `ScBoolPref` `HIDE_VOICE_MESSAGE_BUTTON` (default `false`, opt-in) in `ScPrefs.kt`, surfaced in the Timeline tweaks screen right next to `HIDE_CALL_TOOLBAR_ACTION`.
- Title/summary strings in `schildi/lib/src/main/res/values/strings.xml` (English only).
- A small helper `scShowVoiceRecorderButton()` in the existing `ScSendButtonExtensions.kt`, read in `TextComposer.kt` and added to the `rememberEndButtonParams` key so it reacts to live toggles.
- When the pref is on and the composer is empty (the idle case that would otherwise show the recorder), the end-button slot renders the normal disabled send button instead, so the composer stays usable and tapping where the recorder used to be does not start a recording.

The default is `false`, so existing users see no change unless they opt in. Only the idle entry point is gated; the recording/preview arms are unreachable once the entry button is hidden, so they are left untouched.

## Why this matters

Requested in https://github.com/SchildiChat/schildichat-android-next/issues/99: the voice message button is easy to hit by accident, and on GrapheneOS each accidental tap triggers a microphone-access prompt. SchildiChat Classic offered this toggle. The issue is labeled `open for contributions`.

## Testing

JDK/Android SDK were not available in my environment, so I could not run a Gradle build locally. The change was reviewed line by line against the established Sc pref pattern (`HIDE_CALL_TOOLBAR_ACTION`): same `ScBoolPref` shape, same pref-screen registration, same string naming, reactive `ScPrefs.X.value()` read inside the composable and included in the `remember` key. The new end-button arm reuses the existing `SendButtonIcon(canSendMessage, isEditing)` and `EndButtonParams` shapes already used in the sibling branches. I'd appreciate a CI build to confirm.

Manual test plan:
- Pref OFF (default): record button renders exactly as upstream in an empty composer.
- Pref ON: in an empty composer the record button is gone; the normal send affordance shows and the composer stays usable; no mic-permission prompt when tapping where the button was.
- Typing text then clearing it does not resurrect the recorder button while the pref is ON.

Fixes #99
